### PR TITLE
Feature/41074 Day 14: Adding Sort, and onClick event to Table

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -11,37 +11,48 @@ import TableRow from '@material-ui/core/TableRow';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Paper from '@material-ui/core/Paper';
 
-const useStyles = makeStyles({
+const useStyles = (theme) => ({
   table: {
     minWidth: 650,
   },
   header: {
     color: 'grey',
   },
+  root: {
+    '&:nth-of-type(odd)': {
+      backgroundColor: theme.palette.action.hover,
+    },
+    '&:hover': {
+      backgroundColor: 'rgb(200,200,200)',
+      cursor: 'pointer',
+    },
+  },
 });
 
 function Table1(props) {
-  const classes = useStyles();
   const {
-    column, data, onSelect, onSort, order, orderBy,
+    // eslint-disable-next-line react/prop-types
+    classes, data, column, onSelect, onSort, order, orderBy,
   } = props;
   return (
     <>
       <TableContainer component={Paper}>
         <Table className={classes.table}>
           <TableHead>
-            <TableRow hover>
+            <TableRow>
               {
-                column.map((
-                  { align, label, field },
-                ) => (
-                  <TableCell className={classes.header} align={align}>
+                column.map((Data) => (
+                  <TableCell
+                    className={classes.header}
+                    align={Data.align}
+                    sortDirection={orderBy === Data.label ? order : false}
+                  >
                     <TableSortLabel
-                      align={align}
-                      active={orderBy === field ? order : 'asc'}
-                      onClick={onSort(field)}
+                      active={orderBy === Data.label}
+                      direction={orderBy === Data.label ? order : 'asc'}
+                      onClick={onSort(Data.label)}
                     >
-                      {label}
+                      {Data.label}
                     </TableSortLabel>
                   </TableCell>
                 ))
@@ -50,15 +61,19 @@ function Table1(props) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {data.map(({ name, email, createdAt }) => (
-              <TableRow>
-                <TableCell align={column[0].align}>
-                  {' '}
-                  {name}
-                </TableCell>
-                <TableCell>{email}</TableCell>
-                <TableCell align={column[2].align}>{createdAt}</TableCell>
-
+            {data.trainees.map((element) => (
+              <TableRow
+                key={element.id}
+                className={classes.root}
+                onMouseEnter={onSelect(element)}
+              >
+                {column.map(({ field, align, format }) => (
+                  <TableCell align={align}>
+                    {format !== undefined
+                      ? format(element[field])
+                      : element[field]}
+                  </TableCell>
+                ))}
               </TableRow>
             ))}
           </TableBody>
@@ -68,15 +83,18 @@ function Table1(props) {
   );
 }
 Table1.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   column: PropTypes.arrayOf(PropTypes.object).isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
-  order: PropTypes.oneOf(['asc', 'desc']),
-  onSelect: PropTypes.func.isRequired,
-  onSort: PropTypes.func.isRequired,
+  order: PropTypes.string,
+  orderBy: PropTypes.string,
+  onSort: PropTypes.func,
 };
 
 Table1.defaultProps = {
   order: 'asc',
+  orderBy: '',
+  onSort: () => {},
 };
 
 export default withStyles(useStyles)(Table1);

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -38,13 +38,14 @@ function Table1(props) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {data.map(({ name, email }) => (
+            {data.map(({ name, email, createdAt }) => (
               <TableRow>
                 <TableCell align={column[0].align}>
                   {' '}
                   {name}
                 </TableCell>
                 <TableCell>{email}</TableCell>
+                <TableCell>{createdAt}</TableCell>
 
               </TableRow>
             ))}

--- a/src/pages/Trainee/TraineeList.jsx
+++ b/src/pages/Trainee/TraineeList.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { Grid, Button, withStyles } from '@material-ui/core';
+import { Button, withStyles } from '@material-ui/core';
 import moment from 'moment';
 import { AddDialog } from './components/AddDialog';
 import trainees from './data/trainee';
@@ -21,15 +20,10 @@ class TraineeList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selected: '',
       open: false,
       orderBy: '',
       order: '',
     };
-  }
-
-  getDateFormatted = (date) => {
-    moment(date).format('dddd, MMMM Do YYYY, h:mm:ss a');
   }
 
   handleClickOpen = () => {
@@ -48,29 +42,35 @@ class TraineeList extends React.Component {
     }, () => console.log(data));
   }
 
-  handleSort = (field) => {
+  handleSort = (field) => (event) => {
     const { order } = this.state;
+    console.log(event);
     this.setState({
       orderBy: field,
       order: order === 'asc' ? 'desc' : 'asc',
     });
   }
 
-  handleSelect = (event, data) => {
-    this.setState({ selected: event.target.value }, () => console.log(data));
+  handleSelect = (event) => {
+    console.log(event);
   }
+
+  getDateFormatted = (date) => {
+    moment(date).format('dddd, MMMM Do YYYY, h:mm:ss a');
+  };
 
   render() {
     const { open, orderBy, order } = this.state;
-    const { match: { url }, classes } = this.props;
+    const { classes } = this.props;
     return (
       <>
         <div className={classes.root}>
-          <Grid container direction="row" justify="flex-end" alignItems="flex-end">
+          <div className={classes.dialog}>
             <Button variant="outlined" color="primary" onClick={this.handleClickOpen}>
               ADD TRAINEELIST
             </Button>
-          </Grid>
+            <AddDialog open={open} onClose={this.handleClose} onSubmit={() => this.handleSubmit} />
+          </div>
           <Table1
             id="id"
             data={trainees}
@@ -98,23 +98,12 @@ class TraineeList extends React.Component {
             onSort={this.handleSort}
             onSelect={this.handleSelect}
           />
-          <AddDialog open={open} onClose={this.handleClose} onSubmit={() => this.handleSubmit} />
-          <ul>
-            {trainees.map(({ name, id }) => (
-              <li key={id}>
-                <Link to={`${url}/${id}`}>
-                  {name}
-                </Link>
-              </li>
-            ))}
-          </ul>
         </div>
       </>
     );
   }
 }
 TraineeList.propTypes = {
-  match: PropTypes.objectOf(PropTypes.object).isRequired,
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 export default withStyles(useStyles)(TraineeList);

--- a/src/pages/Trainee/TraineeList.jsx
+++ b/src/pages/Trainee/TraineeList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Button, withStyles } from '@material-ui/core';
+import moment from 'moment';
 import { AddDialog } from './components/AddDialog';
 import trainees from './data/trainee';
 import { Table1 } from '../../components';
@@ -21,6 +22,10 @@ class TraineeList extends React.Component {
     this.state = {
       open: false,
     };
+  }
+
+  getDateFormatted = (date) => {
+    moment(date).format('dddd, MMMM Do YYYY, h:mm:ss a');
   }
 
   handleClickOpen = () => {
@@ -64,8 +69,18 @@ class TraineeList extends React.Component {
                 field: 'email',
                 label: 'Email Address',
               },
+              {
+                field: 'createdAt',
+                label: 'Date',
+                align: 'right',
+                format: this.getDateFormatted,
+              },
 
             ]}
+            // orderBy={orderBy}
+            // order={order}
+            // onSort={this.handleSort}
+            // onSelect={this.handleSelect}
           />
           <AddDialog open={open} onClose={this.handleClose} onSubmit={() => this.handleSubmit} />
           <ul>

--- a/src/pages/Trainee/data/trainee.js
+++ b/src/pages/Trainee/data/trainee.js
@@ -31,4 +31,4 @@ const trainees = [
   },
 ];
 
-export default trainees;
+export default { trainees };


### PR DESCRIPTION
Description

- The table must accept the props as mentioned in the “day-14-props.png”
- New props are as following:
* orderBy; default blank, and will be the name of the field, by which table must be sorted.
* order: Default "asc", and must contain following values, “asc”, “desc”.
* onSort: function to return the selected field
* onSelect: function to return the selected data. and will be used to open the respective detail page.
- Updated columns field:
* format: every column might accept the function that will be used to format the response (optional), as shown in the “da-14-props.png”
- For sorting - only change the arrow dropdown, and don’t sort the data.
- While sorting - If the different field has been clicked, then initial order must be “ASC”, otherwise toggle the order b/w “ASC/DSC”
- Every alternate row must have a different color.
- Hovering the mouse over any row must highlight that row, and cursor must be a pointer.